### PR TITLE
Add support for `prefix` option

### DIFF
--- a/bin/wp-documentor
+++ b/bin/wp-documentor
@@ -49,6 +49,7 @@ $application->register( 'parse' )
 		null
 	)
 	->addOption( 'relative', null, InputOption::VALUE_REQUIRED, 'Relative to directory.', null )
+	->addOption( 'prefix', null, InputOption::VALUE_REQUIRED, 'Comma-separated list of prefixes hooks must match.', null )
 	->addOption( 'output', 'o', InputOption::VALUE_REQUIRED, 'Write output to file instead of stdout.', null )
 	->addOption( 'memory-limit', null, InputOption::VALUE_REQUIRED, 'Memory limit for the run.', null )
 	->addOption(
@@ -124,6 +125,10 @@ $application->register( 'parse' )
 		$relative = $input->getOption( 'relative' );
 
 		$documentor->relative = ( null === $relative ) ? $source : $relative;
+
+		$prefix = $input->getOption( 'prefix' );
+
+		$documentor->prefix = ( null === $prefix ) ? null : $prefix;
 
 		/**
 		 * Output.

--- a/src/Documentor.php
+++ b/src/Documentor.php
@@ -173,6 +173,15 @@ class Documentor {
 				);
 			}
 
+			if ( ! is_null( $this->prefix ) ) {
+				$pattern = sprintf( '/^(%s)/', implode( '|', explode( ',', $this->prefix ) ) );
+				preg_match( $pattern, $tag_name, $matches );
+
+				if ( empty( $matches ) ) {
+					continue;
+				}
+			}
+
 			$tag = new Tag( $tag_name, $tag_arg );
 
 			$doc_comment = $statement->getDocComment();


### PR DESCRIPTION
A new `--prefix` option will allow limiting the output to hooks matching the prefixes passed as a comma-separated list. For example, `--prefix=my_theme,my_plugin` would include `my_theme_some_hook` and `my_plugin_some_other_hook` but exclude `not_my_hook` from the output.

This can be useful when developers need to document the proprietary action and filter hooks introduced by their theme or plugin.