### PR TITLE
Ensure to not print the same hook too often

### DIFF
--- a/templates/phpdocumentor-rst.php
+++ b/templates/phpdocumentor-rst.php
@@ -20,6 +20,7 @@ $eol = "\n";
 $tab = "\t";
 
 $hooks = $documentor->get_hooks();
+$existing_hooks = array();
 
 switch ( $documentor->type ) {
 	case 'actions':
@@ -54,6 +55,11 @@ echo $eol;
 
 foreach ( $hooks as $hook ) {
 	$tag_name = $hook->get_tag()->get_name();
+	
+	if ( in_array( $hook->get_tag()->get_name(), $existing_hooks ) ) {
+		continue;
+	}
+	$existing_hooks[] = $hook->get_tag()->get_name();
 
 	echo $tag_name, $eol;
 	echo str_repeat( '-', \strlen( $tag_name ) ), $eol;


### PR DESCRIPTION
Happens that sometimes a codebase does `apply_filters` or `do_action` the _same_ hook more than once.
With the current template, you then get a DOC with each instance of that `apply_filters` or `do_action` repeated as many times as the codebase uses it.

For example, if you use a `apply_filters( 'list_cats', $r['show_option_all'], null )` more than once (WP does that), your doc would result in a list of several `list_cats`, instead of just one, but you'd not want that.

With the proposed change, the filter or action, if already printed, will be skipped.
It might not be the best solution but avoids n-plicated occurrences of the same filter/action

**NOTE**
The template as such for me was not functional, I had to make changes to get it working, but those changes I will provide in another PR (if that's OK)