### PR TITLE
Fix "Implicitly marking parameter ... as nullable is deprecated, the explicit nullable type must be used instead"

### DIFF
--- a/src/Argument.php
+++ b/src/Argument.php
@@ -80,7 +80,7 @@ class Argument {
 	 *
 	 * @param Param|null $param_tag Param tag.
 	 */
-	public function set_param_tag( Param $param_tag = null ) {
+	public function set_param_tag( ?Param $param_tag = null ) {
 		$this->param_tag = $param_tag;
 	}
 

--- a/src/Hook.php
+++ b/src/Hook.php
@@ -130,7 +130,7 @@ class Hook {
 	 *
 	 * @param \PhpParser\Comment\Doc|null $doc_comment Doc comment.
 	 */
-	public function set_doc_comment( \PhpParser\Comment\Doc $doc_comment = null ) {
+	public function set_doc_comment( ?\PhpParser\Comment\Doc $doc_comment = null ) {
 		$this->doc_comment = $doc_comment;
 	}
 
@@ -286,7 +286,7 @@ class Hook {
 	 *
 	 * @param Changelog|null $changelog Changelog.
 	 */
-	public function set_changelog( Changelog $changelog = null ) {
+	public function set_changelog( ?Changelog $changelog = null ) {
 		$this->changelog = $changelog;
 	}
 


### PR DESCRIPTION
This PR resolves the below error messages, which I noticed when building docs for https://github.com/pronamic/wp-pay-core/:

```
PHP Deprecated:  Pronamic\WordPress\Documentor\Argument::set_param_tag(): Implicitly marking parameter $param_tag as nullable is deprecated, the explicit nullable type must be used instead in /vendor/pronamic/wp-documentor/src/Argument.php on line 83
PHP Deprecated:  Pronamic\WordPress\Documentor\Hook::set_doc_comment(): Implicitly marking parameter $doc_comment as nullable is deprecated, the explicit nullable type must be used instead in /vendor/pronamic/wp-documentor/src/Hook.php on line 133
PHP Deprecated:  Pronamic\WordPress\Documentor\Hook::set_changelog(): Implicitly marking parameter $changelog as nullable is deprecated, the explicit nullable type must be used instead in /vendor/pronamic/wp-documentor/src/Hook.php on line 289
```